### PR TITLE
Proof of concept: Override favorites plugin with a fork

### DIFF
--- a/manifestOverrides.json
+++ b/manifestOverrides.json
@@ -116,6 +116,7 @@
 		"_recommended": true
 	},
 	"joplin.plugin.benji.favorites": {
+		"_superseded_package": "joplin-plugin-benji-favorites",
 		"_recommended": true
 	},
 	"joplin.plugin.benji.persistentLayout": {

--- a/manifests.json
+++ b/manifests.json
@@ -179,7 +179,7 @@
 		],
 		"_publish_hash": "sha256:6f906638826f2d6c6b681af1f53c5e3c4fb2b86c30d98c12b08b76e40a3d1695",
 		"_publish_commit": "master:9bd4f8592ff521ab6329b80e2155307e3d48153c",
-		"_npm_package_name": "joplin-plugin-benji-favorites",
+		"_npm_package_name": "joplin-plugin-personalizedrefrigerator-favorites",
 		"_recommended": true
 	},
 	"outline": {


### PR DESCRIPTION
> [!WARNING]
> **This is a proof of concept.** Do not merge as is.
>
> Rather than using my NPM package, a version of the favorites plugin should be published to the Joplin organization on NPM (e.g. `@joplin/joplin-plugin-favorites`). This prevents users from switching from a maintainer that they may trust (@benji300) to another maintainer that they may not have researched/decided to trust.



This pull request demonstrates marking a plugin as superseded by another. The new plugin has the same ID and can, as such, be updated without losing users' data.


