### PR TITLE
Add io.github.jackgruber.notelist as obsolete

### DIFF
--- a/manifestOverrides.json
+++ b/manifestOverrides.json
@@ -245,5 +245,33 @@
 		"_publish_commit": "main:0d2e629fa86c54c8b4e010af948864a175068f30",
 		"_npm_package_name": "joplin-plugin-tags-generator",
 		"_obsolete": true
+	},
+	"io.github.jackgruber.notelist": {
+		"manifest_version": 1,
+		"id": "io.github.jackgruber.notelist",
+		"app_min_version": "2.13",
+		"version": "0.0.1",
+		"name": "Note list (Preview)",
+		"description": "Displays a note priview in the note list",
+		"author": "JackGruber",
+		"homepage_url": "https://github.com/JackGruber/joplin-plugin-notelist/README.md",
+		"repository_url": "https://github.com/JackGruber/joplin-plugin-notelist",
+		"keywords": [
+			"priview",
+			"vorschau",
+			"notiz",
+			"note",
+			"notelist"
+		],
+		"categories": [
+			"themes",
+			"productivity"
+		],
+		"screenshots": [],
+		"icons": {},
+		"_publish_hash": "sha256:7e1d709c1f5daba491d29fdf0c8ff9682e5d6edd9466749319e6aa3f4f46fda9",
+		"_publish_commit": "master:736446fe9cbadd872d0c7e853e6d44ea275411f2",
+		"_npm_package_name": "joplin-plugin-notelist",
+		"_obsolete": true
 	}
 }


### PR DESCRIPTION
Plugin was published in the first version with a wrong id and name