### PR TITLE
Mark com.github.joplin-claude as obsolete (renamed to Joplin Aide)

### DIFF
--- a/manifestOverrides.json
+++ b/manifestOverrides.json
@@ -699,6 +699,6 @@
 		],
 		"_npm_package_name": "joplin-plugin-claude",
 		"_obsolete": true,
-		"_obsolete_reason": "Renamed to Joplin Aide (com.github.joplin-aide, npm: joplin-plugin-aide) - same plugin under a new id, now with dual AI backend (Claude Code / GitHub Copilot CLI). Please install Joplin Aide instead."
+		"_obsolete_reason": "Renamed to Joplin Aide (com.github.joplin-aide, npm: joplin-plugin-aide) - same plugin under a new id, now with dual AI backends (Claude Code / GitHub Copilot CLI). Please install Joplin Aide instead."
 	}
 }

--- a/manifestOverrides.json
+++ b/manifestOverrides.json
@@ -677,5 +677,28 @@
 		"_npm_package_name": "joplin-plugin-resource-search",
 		"_obsolete": true,
 		"_obsolete_reason": "Causes severe memory leak when processing PDF files - https://github.com/laurent22/joplin/issues/14359"
+	},
+	"com.github.joplin-claude": {
+		"manifest_version": 1,
+		"id": "com.github.joplin-claude",
+		"app_min_version": "2.8",
+		"version": "0.4.2",
+		"name": "Joplin Claude",
+		"description": "Chat with Claude inside Joplin. Claude can read, search, create and edit your notes through your local Claude Code CLI. Write operations require your confirmation.",
+		"author": "lim0513",
+		"homepage_url": "https://github.com/lim0513/joplin-claude",
+		"repository_url": "https://github.com/lim0513/joplin-claude",
+		"keywords": [
+			"claude",
+			"ai",
+			"assistant",
+			"chat"
+		],
+		"categories": [
+			"productivity"
+		],
+		"_npm_package_name": "joplin-plugin-claude",
+		"_obsolete": true,
+		"_obsolete_reason": "Renamed to Joplin Aide (com.github.joplin-aide, npm: joplin-plugin-aide) - same plugin under a new id, now with dual AI backend (Claude Code / GitHub Copilot CLI). Please install Joplin Aide instead."
 	}
 }

--- a/manifests.json
+++ b/manifests.json
@@ -8332,27 +8332,6 @@
 		"_publish_commit": "main:0558879a9fdce41b6fcc5f55949077944824af12",
 		"_npm_package_name": "joplin-plugin-inline-todo-gui"
 	},
-	"com.github.joplin-claude": {
-		"manifest_version": 1,
-		"id": "com.github.joplin-claude",
-		"app_min_version": "2.8",
-		"version": "0.4.2",
-		"name": "Joplin Claude",
-		"description": "Chat with Claude inside Joplin. Claude can read, search, create and edit your notes through your local Claude Code CLI. Write operations require your confirmation.",
-		"author": "lim0513",
-		"homepage_url": "https://github.com/lim0513/joplin-claude",
-		"repository_url": "https://github.com/lim0513/joplin-claude",
-		"keywords": [
-			"claude",
-			"ai",
-			"assistant",
-			"chat"
-		],
-		"categories": [
-			"productivity"
-		],
-		"_npm_package_name": "joplin-plugin-claude"
-	},
 	"com.github.joplin-aide": {
 		"manifest_version": 1,
 		"id": "com.github.joplin-aide",


### PR DESCRIPTION
I am the author of this plugin. It has been renamed to **Joplin Aide** (id: com.github.joplin-aide, npm: joplin-plugin-aide), which is already in the repository - same plugin under a new id, now with dual AI backend support (Claude Code / GitHub Copilot CLI).

The old npm package joplin-plugin-claude is deprecated with a pointer to the new one. Marking the old id obsolete so users find only the maintained plugin in search.

Both JSON files validated.